### PR TITLE
Update to Quarkus 1.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
   <artifactId>oauthdemo</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>0.23.1</quarkus.version>
+    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <quarkus.version>1.11.1.Final</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -50,8 +50,13 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.8</version>
+      <version>1.18.16</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-security</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/okta/quarkus/jwt/TokenSecuredResource.java
+++ b/src/main/java/com/okta/quarkus/jwt/TokenSecuredResource.java
@@ -28,7 +28,7 @@ public class TokenSecuredResource {
 
     @Inject
     @Claim("groups")
-    private Set<String> groups;
+    Set<String> groups;
 
     @GET()
     @Path("permit-all")
@@ -52,7 +52,7 @@ public class TokenSecuredResource {
         String name = caller == null ? "anonymous" : caller.getName();
         boolean hasJWT = jwt != null;
         String groupsString = groups != null ? groups.toString() : "";
-        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s, groups: %s\"", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT, groupsString);
+        String helloReply = String.format("hello + %s, isSecure: %s, authScheme: %s, hasJWT: %s, groups: %s", name, ctx.isSecure(), ctx.getAuthenticationScheme(), hasJWT, groupsString);
         return helloReply;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,2 @@
 mp.jwt.verify.publickey.location=https://dev-533919.oktapreview.com/oauth2/default/v1/keys
 mp.jwt.verify.issuer=https://dev-533919.oktapreview.com/oauth2/default
-quarkus.smallrye-jwt.auth-mechanism=MP-JWT
-quarkus.smallrye-jwt.enabled=true

--- a/src/test/java/com/okta/quarkus/jwt/NativeTokenSecuredResourceIT.java
+++ b/src/test/java/com/okta/quarkus/jwt/NativeTokenSecuredResourceIT.java
@@ -1,8 +1,8 @@
 package com.okta.quarkus.jwt;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeTokenSecuredResourceIT extends TokenSecuredResourceTest {
 
     // Execute the same tests but in native mode.

--- a/src/test/java/com/okta/quarkus/jwt/TokenSecuredResourceTest.java
+++ b/src/test/java/com/okta/quarkus/jwt/TokenSecuredResourceTest.java
@@ -1,7 +1,18 @@
 package com.okta.quarkus.jwt;
 
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.smallrye.jwt.runtime.auth.QuarkusJwtCallerPrincipal;
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestIdentityAssociation;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jose4j.jwt.JwtClaims;
 import org.junit.jupiter.api.Test;
+
+import javax.enterprise.inject.spi.CDI;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
@@ -10,12 +21,44 @@ import static org.hamcrest.CoreMatchers.is;
 public class TokenSecuredResourceTest {
 
     @Test
-    public void testHelloEndpoint() {
+    public void testPermitAllEndpoint() {
         given()
-          .when().get("/secured")
+          .when().get("/secured/permit-all")
           .then()
              .statusCode(200)
-             .body(is("hello"));
+             .body(is("hello + anonymous, isSecure: false, authScheme: null, hasJWT: true, groups: "));
     }
 
+    @Test
+    public void testHelloEndpoint() {
+        given()
+                .when().get("/secured")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @DisabledOnNativeImage
+    public void testHelloEndpointWithUser() {
+        // work around for: https://github.com/quarkusio/quarkus/issues/11695
+        configureTestUser("testuser", Set.of("Everyone"));
+
+        given()
+                .when().get("/secured")
+                .then()
+                .statusCode(200)
+                .body(is("hello + testuser, isSecure: false, authScheme: null, hasJWT: true, groups: [Everyone]"));
+    }
+
+    private void configureTestUser(String name, Set<String> roles) {
+        JwtClaims claims = new JwtClaims();
+        claims.setClaim("groups", new ArrayList<>(roles));
+        JsonWebToken jwt = new QuarkusJwtCallerPrincipal(name, claims);
+
+        QuarkusSecurityIdentity user = QuarkusSecurityIdentity.builder()
+                .setPrincipal(jwt)
+                .addRoles(new HashSet<>(roles))
+                .build();
+        CDI.current().select(TestIdentityAssociation.class).get().setTestIdentity(user);
+    }
 }


### PR DESCRIPTION
It looks like the tests were not working in this repo, so I updated to the latest version of Quarkus and fixed the test.

I was able to manually validate using a JWT as a bearer token worked, but it did NOT work when running as a native image.  I couldn't get the current version to event build the native-image, so i'm not sure this is an issue

```txt
OpenJDK Runtime Environment GraalVM CE 20.3.0 (build 11.0.9+10-jvmci-20.3-b06)
OpenJDK 64-Bit Server VM GraalVM CE 20.3.0 (build 11.0.9+10-jvmci-20.3-b06, mixed mode, sharing)
```
